### PR TITLE
Make datafeeder header configurable

### DIFF
--- a/.github/workflows/datafeeder.yaml
+++ b/.github/workflows/datafeeder.yaml
@@ -3,41 +3,41 @@ name: Build
 on:
   push:
     branches:
-    - georchestra-datafeeder
+      - georchestra-datafeeder
     tags:
-    - '*'
+      - '*'
 jobs:
   build:
     if: github.repository == 'georchestra/geonetwork-ui'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - name: 'Checking out'
-      uses: actions/checkout@v1
+      - name: 'Checking out'
+        uses: actions/checkout@v1
 
-    - name: Getting image tag
-      if: github.repository == 'georchestra/geonetwork-ui'
-      id: version
-      run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
+      - name: Getting image tag
+        if: github.repository == 'georchestra/geonetwork-ui'
+        id: version
+        run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
 
-    - name: 'Building docker image'
-      if: github.repository == 'georchestra/geonetwork-ui'
-      run: docker build -t georchestra/datafeeder-frontend:latest .
+      - name: 'Building docker image'
+        if: github.repository == 'georchestra/geonetwork-ui'
+        run: docker build -t georchestra/datafeeder-frontend:latest .
 
-    - name: 'Logging in to docker.io'
-      if: github.repository == 'georchestra/geonetwork-ui'
-      uses: azure/docker-login@v1
-      with:
-        username: '${{ secrets.DOCKER_HUB_USERNAME }}'
-        password: '${{ secrets.DOCKER_HUB_PASSWORD }}'
+      - name: 'Logging in to docker.io'
+        if: github.repository == 'georchestra/geonetwork-ui'
+        uses: azure/docker-login@v1
+        with:
+          username: '${{ secrets.DOCKER_HUB_USERNAME }}'
+          password: '${{ secrets.DOCKER_HUB_PASSWORD }}'
 
-    - name: 'Pushing the docker image onto docker.io'
-      if: github.ref == 'refs/heads/georchestra-datafeeder' && github.repository == 'georchestra/geonetwork-ui'
-      run: |
-        docker push georchestra/datafeeder-frontend:latest
+      - name: 'Pushing the docker image onto docker.io'
+        if: github.ref == 'refs/heads/georchestra-datafeeder' && github.repository == 'georchestra/geonetwork-ui'
+        run: |
+          docker push georchestra/datafeeder-frontend:latest
 
-    - name: "Pushing release to docker.io"
-      if: contains(github.ref, 'refs/tags/') && github.repository == 'georchestra/geonetwork-ui'
-      run: |
-        docker tag georchestra/datafeeder-frontend:latest georchestra/datafeeder-frontend:${{ steps.version.outputs.VERSION }}
-        docker push georchestra/datafeeder-frontend:${{ steps.version.outputs.VERSION }}
+      - name: 'Pushing release to docker.io'
+        if: contains(github.ref, 'refs/tags/') && github.repository == 'georchestra/geonetwork-ui'
+        run: |
+          docker tag georchestra/datafeeder-frontend:latest georchestra/datafeeder-frontend:${{ steps.version.outputs.VERSION }}
+          docker push georchestra/datafeeder-frontend:${{ steps.version.outputs.VERSION }}

--- a/apps/datafeeder/src/app/app.component.html
+++ b/apps/datafeeder/src/app/app.component.html
@@ -1,1 +1,7 @@
+<iframe
+  [style.height]="headerHeight"
+  [src]="headerSrc | safe: 'resourceUrl'"
+  scrolling="no"
+  frameborder="0"
+></iframe>
 <router-outlet></router-outlet>

--- a/apps/datafeeder/src/app/app.component.spec.ts
+++ b/apps/datafeeder/src/app/app.component.spec.ts
@@ -1,24 +1,35 @@
 import { TestBed } from '@angular/core/testing'
 import { RouterTestingModule } from '@angular/router/testing'
 import { AppComponent } from './app.component'
+import { UtilSharedModule } from '@geonetwork-ui/util/shared'
+import SETTINGS from '../settings'
 
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
+      imports: [RouterTestingModule, UtilSharedModule],
       declarations: [AppComponent],
     }).compileComponents()
   })
 
-  it('should create the app', () => {
-    const fixture = TestBed.createComponent(AppComponent)
-    const app = fixture.componentInstance
-    expect(app).toBeTruthy()
-  })
-
-  it(`should have as title 'datafeeder'`, () => {
-    const fixture = TestBed.createComponent(AppComponent)
-    const app = fixture.componentInstance
-    expect(app.title).toEqual('datafeeder')
+  describe('', () => {
+    let fixture
+    let app
+    beforeEach(async () => {
+      fixture = TestBed.createComponent(AppComponent)
+      app = fixture.componentInstance
+    })
+    it('should create the app', () => {
+      expect(app).toBeTruthy()
+    })
+    it(`should have as title 'datafeeder'`, () => {
+      expect(app.title).toEqual('datafeeder')
+    })
+    it(`should have SETTINGS.headerHeight as height`, () => {
+      expect(app.headerHeight).toEqual(SETTINGS.headerHeight)
+    })
+    it(`should have SETTINGS.headerSrc as src`, () => {
+      expect(app.headerSrc).toEqual(SETTINGS.headerSrc)
+    })
   })
 })

--- a/apps/datafeeder/src/app/app.component.ts
+++ b/apps/datafeeder/src/app/app.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core'
 import { ThemeService } from '@geonetwork-ui/util/shared'
+import SETTINGS from '../settings'
 
 @Component({
   selector: 'gn-ui-root',
@@ -8,6 +9,8 @@ import { ThemeService } from '@geonetwork-ui/util/shared'
 })
 export class AppComponent implements OnInit {
   title = 'datafeeder'
+  headerSrc = SETTINGS.headerSrc
+  headerHeight = SETTINGS.headerHeight
 
   ngOnInit() {
     ThemeService.applyCssVariables('#1EA9D5', '#EF7749', '#2E353A', '#fff')

--- a/apps/datafeeder/src/app/app.module.ts
+++ b/apps/datafeeder/src/app/app.module.ts
@@ -37,6 +37,7 @@ import { SummarizePageComponent } from './presentation/pages/summarize-page/summ
 import { SummarizeIllustrationComponent } from './presentation/components/svg/summarize-illustration/summarize-illustration.component'
 import { SummarizeBackgroundComponent } from './presentation/components/svg/summarize-background/summarize-background.component'
 import { DATAFEEDER_STATE_KEY, reducer } from './store/datafeeder.reducer'
+import { UtilSharedModule } from '@geonetwork-ui/util/shared'
 
 export function apiConfigurationFactory() {
   return new Configuration({
@@ -74,6 +75,7 @@ export function apiConfigurationFactory() {
     UiWidgetsModule,
     HttpClientModule,
     UtilI18nModule,
+    UtilSharedModule,
     FeatureEditorModule,
     ApiModule.forRoot(apiConfigurationFactory),
     TranslateModule.forRoot(TRANSLATE_DEFAULT_CONFIG),

--- a/apps/datafeeder/src/app/presentation/components/data-import-validation-map-panel/data-import-validation-map-panel.component.html
+++ b/apps/datafeeder/src/app/presentation/components/data-import-validation-map-panel/data-import-validation-map-panel.component.html
@@ -8,7 +8,17 @@
     <div
       *ngIf="showProperties"
       [style.background]="getSecondaryColor(0.75)"
-      class="z-10 absolute top-0 w-56 right-1/10 p-3 h-full max-w-full overflow-y-auto"
+      class="
+        z-10
+        absolute
+        top-0
+        w-56
+        right-1/10
+        p-3
+        h-full
+        max-w-full
+        overflow-y-auto
+      "
     >
       <div class="text-sm text-white" *ngFor="let property of getProperties()">
         <strong>{{ property[0] }}</strong
@@ -29,7 +39,15 @@
       </gn-ui-dropdown-selector>
       <span
         *ngIf="footerList.length === 0"
-        class="block uppercase tracking-wide text-gray-800 text-xs font-bold whitespace-no-wrap text-right"
+        class="
+          block
+          uppercase
+          tracking-wide
+          text-gray-800 text-xs
+          font-bold
+          whitespace-no-wrap
+          text-right
+        "
       >
         {{ footerLabel | translate }} {{ selectedValue | translate }}
       </span>

--- a/apps/datafeeder/src/index.html
+++ b/apps/datafeeder/src/index.html
@@ -11,21 +11,9 @@
       href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&family=Permanent+Marker&display=swap"
       rel="stylesheet"
     />
-
-    <script src="assets/env.js"></script>
-    <style>
-      iframe {
-        height: 90px;
-      }
-    </style>
     <script src="assets/env.js"></script>
   </head>
   <body class="m-0 h-full flex flex-col">
-    <iframe
-      src="/header/?active=import"
-      scrolling="no"
-      frameborder="0"
-    ></iframe>
     <gn-ui-root class="flex flex-col flex-1"></gn-ui-root>
   </body>
 </html>

--- a/apps/datafeeder/src/settings.ts
+++ b/apps/datafeeder/src/settings.ts
@@ -4,6 +4,8 @@ import { environment } from './environments/environment'
 const SETTING_API = `${environment.apiUrl}/config/frontend`
 
 class Settings {
+  headerHeight = '90px'
+  headerSrc = '/header/?active=import'
   encodings = [
     {
       label: 'UTF-8',


### PR DESCRIPTION
PR moves the header iframe from the `index.html` to the `app.component` and allows defining its `headerHeight` and `headerSrc` from the settings (which are fetched from the datadir if present, cf `frontend-config.json`)