### PR TITLE
[datafeeder] Fix tailwind-related errors at build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
 demo
 node_modules
 ssr
+.angular
+dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,9 @@ FROM node:14-alpine as build
 WORKDIR /app
 COPY package.json ./
 COPY package-lock.json ./
-RUN npm install
+RUN npm ci --ignore-scripts
 COPY . ./
+RUN npm run postinstall
 RUN npm run build datafeeder -- --base-href='/import/'
 
 # Runner


### PR DESCRIPTION
This PR makes the post install scripts run in the docker build. Without these Nx does not have the dependency graph and fails to generate the tailwind config, producing such errors:

```
[createGlobPatternsForDependencies] WARNING: There was no ProjectGraph available to read from, returning an empty array of glob patterns
```

And the resulting CSS file misses many tailwind classes.

Postinstall sripts used to fail because they could not run only with `package.json` and `package-lock.json` but also needed the rest of the source code.
