### PR TITLE
Set Nx defaultBase to georchestra-datafeeder

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -7,7 +7,7 @@
     ".eslintrc.json": "*"
   },
   "affected": {
-    "defaultBase": "remotes/origin/master"
+    "defaultBase": "remotes/origin/georchestra-datafeeder"
   },
   "npmScope": "geonetwork-ui",
   "tasksRunnerOptions": {


### PR DESCRIPTION
PR sets Nx `defaultBase` for the `affected` build commands to `georchestra-datafeeder`, since `master` is not updated (and relevant so far) in this repository. If the build of this PR passes, it should fix the failing builds (due to prettier) in current open PRs.
I guess an alternative would be to keep `master` up to date with upstream, but this would add a branch to maintain, that we currently do not use.