### PR TITLE
Implement custom scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM nginx:1.21.4-alpine
 RUN rm -rf /usr/share/nginx/html/*
 COPY dist/apps/datafeeder /usr/share/nginx/html
 COPY nginx-default.conf /etc/nginx/conf.d/default.conf
+COPY custom-start.sh /custom-start.sh
 EXPOSE 80
 
+ENTRYPOINT ["sh", "/custom-start.sh", "sh", "/docker-entrypoint.sh"]
 CMD ["nginx", "-g", "daemon off;"]

--- a/apps/datafeeder/src/app/app.component.html
+++ b/apps/datafeeder/src/app/app.component.html
@@ -1,7 +1,1 @@
-<iframe
-  [style.height]="headerHeight"
-  [src]="headerSrc | safe: 'resourceUrl'"
-  scrolling="no"
-  frameborder="0"
-></iframe>
 <router-outlet></router-outlet>

--- a/apps/datafeeder/src/app/app.component.spec.ts
+++ b/apps/datafeeder/src/app/app.component.spec.ts
@@ -2,7 +2,6 @@ import { TestBed } from '@angular/core/testing'
 import { RouterTestingModule } from '@angular/router/testing'
 import { AppComponent } from './app.component'
 import { UtilSharedModule } from '@geonetwork-ui/util/shared'
-import SETTINGS from '../settings'
 
 describe('AppComponent', () => {
   beforeEach(async () => {
@@ -24,12 +23,6 @@ describe('AppComponent', () => {
     })
     it(`should have as title 'datafeeder'`, () => {
       expect(app.title).toEqual('datafeeder')
-    })
-    it(`should have SETTINGS.headerHeight as height`, () => {
-      expect(app.headerHeight).toEqual(SETTINGS.headerHeight)
-    })
-    it(`should have SETTINGS.headerSrc as src`, () => {
-      expect(app.headerSrc).toEqual(SETTINGS.headerSrc)
     })
   })
 })

--- a/apps/datafeeder/src/app/app.component.ts
+++ b/apps/datafeeder/src/app/app.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit } from '@angular/core'
 import { ThemeService } from '@geonetwork-ui/util/shared'
-import SETTINGS from '../settings'
 
 @Component({
   selector: 'gn-ui-root',
@@ -9,8 +8,6 @@ import SETTINGS from '../settings'
 })
 export class AppComponent implements OnInit {
   title = 'datafeeder'
-  headerSrc = SETTINGS.headerSrc
-  headerHeight = SETTINGS.headerHeight
 
   ngOnInit() {
     ThemeService.applyCssVariables('#1EA9D5', '#EF7749', '#2E353A', '#fff')

--- a/apps/datafeeder/src/index.html
+++ b/apps/datafeeder/src/index.html
@@ -11,6 +11,10 @@
       href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&family=Permanent+Marker&display=swap"
       rel="stylesheet"
     />
+    <link
+      href="https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined"
+      rel="stylesheet"
+    />
     <script src="assets/env.js"></script>
   </head>
   <body class="m-0 h-full flex flex-col">

--- a/apps/datafeeder/src/settings.ts
+++ b/apps/datafeeder/src/settings.ts
@@ -4,8 +4,6 @@ import { environment } from './environments/environment'
 const SETTING_API = `${environment.apiUrl}/config/frontend`
 
 class Settings {
-  headerHeight = '90px'
-  headerSrc = '/header/?active=import'
   encodings = [
     {
       label: 'UTF-8',

--- a/custom-start.sh
+++ b/custom-start.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+DIR=/docker-entrypoint.d
+
+# Executing custom scripts located in CUSTOM_SCRIPTS_DIRECTORY if environment variable is set
+if [[ -z "${CUSTOM_SCRIPTS_DIRECTORY}" ]]; then
+  echo "[INFO] No CUSTOM_SCRIPTS_DIRECTORY env variable set"
+else
+  echo "[INFO] CUSTOM_SCRIPTS_DIRECTORY env variable set to ${CUSTOM_SCRIPTS_DIRECTORY}"
+  cp -v "${CUSTOM_SCRIPTS_DIRECTORY}"/* "$DIR"
+  echo "[INFO] End copying custom scripts"
+fi
+
+if [[ -d "$DIR" ]]
+then
+  # No regex and verbose in this image
+  /bin/run-parts "$DIR"
+fi
+
+exec "$@"


### PR DESCRIPTION
# Custom scripts 

This PR adds the capability to run scripts at startup of the container.

It's a part of the georchestra PR :
- https://github.com/georchestra/georchestra/pull/4083

Soving issue : 
- https://github.com/georchestra/georchestra/issues/4030

## Changes

### Header script
Old iframe header is removed from the image and can be available while with an `sh` script (e.g. use iframe header): 
``` sh
DATAFEEDER_DIR=${1:-/usr/share/nginx/html/}
SNIPPET="<script src='https://cdn.jsdelivr.net/gh/georchestra/header@dist/header.js'></script><geor-header active-app='import' style='height:90px' legacy-header="true" legacy-url="/header/"></geor-header>"

if grep -q "${SNIPPET}" "${DATAFEEDER_DIR}/index.html"; then
  echo "[INFO] geOrchestra: header already present."
  exit 0
fi

echo "[INFO] geOrchestra: adding header in the main page..."
sed -i "s#<body class=\"m-0 h-full flex flex-col\">#<body class=\"m-0 h-full flex flex-col\">${SNIPPET}#" ${DATAFEEDER_DIR}/index.html

```
For all informations about the header : see [README.md](https://github.com/georchestra/header)

### Startup script

A `custom-startup.sh` script is implemented in order to avoid overriding Nginx default script.

## How-to

Set  `CUSTOM_SCRIPTS_DIRECTORY` environment variable to point to a valid volume.
Set a volume with scripts to execute.


Example :
```
 import:
    ...
    volumes:
      - georchestra_datadir:/etc/georchestra
    environment:
      - CUSTOM_SCRIPTS_DIRECTORY=/etc/georchestra/import/scripts
```