### PR TITLE
Webcomponent header

### DIFF
--- a/apps/datafeeder/src/app/app.component.html
+++ b/apps/datafeeder/src/app/app.component.html
@@ -1,7 +1,1 @@
-<iframe
-  [style.height]="headerHeight"
-  [src]="headerSrc | safe: 'resourceUrl'"
-  scrolling="no"
-  frameborder="0"
-></iframe>
 <router-outlet></router-outlet>

--- a/apps/datafeeder/src/app/app.component.spec.ts
+++ b/apps/datafeeder/src/app/app.component.spec.ts
@@ -2,7 +2,6 @@ import { TestBed } from '@angular/core/testing'
 import { RouterTestingModule } from '@angular/router/testing'
 import { AppComponent } from './app.component'
 import { UtilSharedModule } from '@geonetwork-ui/util/shared'
-import SETTINGS from '../settings'
 
 describe('AppComponent', () => {
   beforeEach(async () => {
@@ -24,12 +23,6 @@ describe('AppComponent', () => {
     })
     it(`should have as title 'datafeeder'`, () => {
       expect(app.title).toEqual('datafeeder')
-    })
-    it(`should have SETTINGS.headerHeight as height`, () => {
-      expect(app.headerHeight).toEqual(SETTINGS.headerHeight)
-    })
-    it(`should have SETTINGS.headerSrc as src`, () => {
-      expect(app.headerSrc).toEqual(SETTINGS.headerSrc)
     })
   })
 })

--- a/apps/datafeeder/src/app/app.component.ts
+++ b/apps/datafeeder/src/app/app.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit } from '@angular/core'
 import { ThemeService } from '@geonetwork-ui/util/shared'
-import SETTINGS from '../settings'
 
 @Component({
   selector: 'gn-ui-root',
@@ -9,8 +8,6 @@ import SETTINGS from '../settings'
 })
 export class AppComponent implements OnInit {
   title = 'datafeeder'
-  headerSrc = SETTINGS.headerSrc
-  headerHeight = SETTINGS.headerHeight
 
   ngOnInit() {
     ThemeService.applyCssVariables('#1EA9D5', '#EF7749', '#2E353A', '#fff')

--- a/apps/datafeeder/src/settings.ts
+++ b/apps/datafeeder/src/settings.ts
@@ -4,8 +4,6 @@ import { environment } from './environments/environment'
 const SETTING_API = `${environment.apiUrl}/config/frontend`
 
 class Settings {
-  headerHeight = '90px'
-  headerSrc = '/header/?active=import'
   encodings = [
     {
       label: 'UTF-8',


### PR DESCRIPTION
# Webcomponent header

Needs resolution of PR : 
- https://github.com/georchestra/geonetwork-ui/pull/7

Implements the new georchestra/header in datafeeder-ui.
Main PR : 
- https://github.com/georchestra/georchestra/pull/4065

## Changes

### Header script
Old iframe header is removed from the image and can be available while with an `sh` script (e.g. use iframe header): 
``` sh
DATAFEEDER_DIR=${1:-/usr/share/nginx/html/}
SNIPPET="<script src='https://cdn.jsdelivr.net/gh/georchestra/header@dist/header.js'></script><geor-header active-app='import' style='height:90px' legacy-header="true" legacy-url="/header/"></geor-header>"

if grep -q "${SNIPPET}" "${DATAFEEDER_DIR}/index.html"; then
  echo "[INFO] geOrchestra: header already present."
  exit 0
fi

echo "[INFO] geOrchestra: adding header in the main page..."
sed -i "s#<body class=\"m-0 h-full flex flex-col\">#<body class=\"m-0 h-full flex flex-col\">${SNIPPET}#" ${DATAFEEDER_DIR}/index.html

```
For all informations about the header : see [README.md](https://github.com/georchestra/header)

