### PR TITLE
fix : tools pipelines when organisationObject is used

### DIFF
--- a/tools/pipelines/register-es-pipelines.js
+++ b/tools/pipelines/register-es-pipelines.js
@@ -69,7 +69,7 @@ if(ctx.resourceTitleObject != null && ctx.resourceTitleObject.default != null &&
 if(ctx.resourceAbstractObject != null && ctx.resourceAbstractObject.default != null && ctx.resourceAbstractObject.default != '') {
   ok++
 }
-if(ctx.contact != null && ctx.contact.length > 0 && ctx.contact[0].organisation != null && ctx.contact[0].organisation != '') {
+if(ctx.contact != null && ctx.contact.length > 0 && ((ctx.contact[0].organisation != null && ctx.contact[0].organisation != '') || (ctx.contact[0].organisationObject.default != null && ctx.contact[0].organisationObject.default != ''))) {
   ok++
 }
 if(ctx.contact != null && ctx.contact.length > 0 && ctx.contact[0].email != null && ctx.contact[0].email != '') {


### PR DESCRIPTION
### Description

This PR introduces  a fix to tool pipeline in order to get ok++ on more recent version of index.

Contact in index : 
```json
"contact": [
      {
          "website": "",
          "role": "pointOfContact",
          "address": "1 myadress",
          "individual": "",
          "phone": "myphone",
          "logo": "",
          "position": "",
          "organisationObject": {
              "default": "my org",
              "langfre": "my org"
          },
          "email": "myemail"
      }
  ],
```


### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

