### PR TITLE
Allow editing end links for datafeeder

### DIFF
--- a/apps/datafeeder/src/app/presentation/pages/success-publish-page/success-publish-page.component.html
+++ b/apps/datafeeder/src/app/presentation/pages/success-publish-page/success-publish-page.component.html
@@ -12,31 +12,12 @@
       </div>
       <div class="flex-1 flex flex-col justify-between pl-20">
         <div class="flex flex-col pt-8">
-          <gn-ui-button
-            type="primary"
-            *ngIf="gnLink"
-            extraClass="rounded-full px-20 mb-2"
-            (buttonClick)="openGeonetworkLink()"
-            ><span translate class="uppercase text-white font-bold"
-              >datafeeder.publishSuccess.geonetworkRecord</span
-            ></gn-ui-button
-          >
-          <gn-ui-button
+          <gn-ui-button *ngFor="let link of linksToDisplay"
             type="primary"
             extraClass="rounded-full px-20 mb-2"
-            *ngIf="gsLink"
-            (buttonClick)="openGeoserverLink()"
-            ><span class="uppercase text-white font-bold" translate
-              >datafeeder.publishSuccess.mapViewer</span
-            ></gn-ui-button
-          >
-          <gn-ui-button
-            type="primary"
-            *ngIf="ogcLink"
-            extraClass="rounded-full px-20"
-            (buttonClick)="openOgcLink()"
-            ><span class="uppercase text-white font-bold" translate
-              >datafeeder.publishSuccess.ogcFeature</span
+            (buttonClick)="openLink(link.uri)"
+            ><span class="uppercase text-white font-bold"
+              >{{link.label}}</span
             ></gn-ui-button
           >
         </div>

--- a/apps/datafeeder/src/app/presentation/pages/success-publish-page/success-publish-page.component.ts
+++ b/apps/datafeeder/src/app/presentation/pages/success-publish-page/success-publish-page.component.ts
@@ -56,16 +56,15 @@ export class SuccessPublishPageComponent implements OnInit, OnDestroy {
         .pipe(take(1))
         .subscribe((job: JobStatusModel) => {
           const links = job.datasets[0]._links
-          const linksFromConfig = SETTINGS.links
-          // Existing links
-          linksFromConfig.existing?.forEach((link) => {
+          SETTINGS.links.forEach((link) => {
             if (link === ('geonetwork')) {
               this.gnLink = links.describedBy[1].href.replace(
                 '/eng/',
                 `/${LANG_2_TO_3_MAPPER[this.translateService.currentLang]}/`
               )
               this.linksToDisplay.push({uri: this.gnLink, label: this.translateService.instant('datafeeder.publishSuccess.geonetworkRecord')})
-            } else if (link === ('openlayers')) {
+            }
+            else if (link === ('openlayers')) {
               this.gsLink = links.preview?.href
               this.http
                 .get(this.gsLink, { observe: 'response', responseType: 'text' })
@@ -79,15 +78,14 @@ export class SuccessPublishPageComponent implements OnInit, OnDestroy {
                     this.linksToDisplay.push({uri: this.gsLink, label: this.translateService.instant('datafeeder.publishSuccess.mapViewer')})
                   }
                 })
-            } else if (link === ('ogc-features')) {
+            }
+            else if (link === ('ogc-features')) {
               this.ogcLink = links.hosts?.href
               if (this.ogcLink)
                 this.linksToDisplay.push({uri: this.ogcLink, label: this.translateService.instant('datafeeder.publishSuccess.ogcFeature')})
+            } else {
+              this.linksToDisplay.push({uri: this.replaceVars(link.uri, job.datasets[0]), label: link.title[this.translateService.currentLang] || link.title.default})
             }
-          })
-          //Custom links
-          linksFromConfig.custom?.forEach((link) => {
-            this.linksToDisplay.push({uri: this.replaceVars(link.uri, job.datasets[0]), label: link.title[this.translateService.currentLang] || link.title.default})
           })
         })
     )

--- a/apps/datafeeder/src/app/presentation/pages/success-publish-page/success-publish-page.component.ts
+++ b/apps/datafeeder/src/app/presentation/pages/success-publish-page/success-publish-page.component.ts
@@ -11,6 +11,8 @@ import { Subscription } from 'rxjs'
 import { take } from 'rxjs/operators'
 import { DatafeederFacade } from '../../../store/datafeeder.facade'
 import { HttpClient } from '@angular/common/http'
+import SETTINGS from "../../../../settings";
+import {marker} from "@biesbjerg/ngx-translate-extract-marker";
 
 interface DatasetModel extends DatasetPublishingStatusApiModel {
   _links: any
@@ -23,6 +25,10 @@ export interface JobStatusModel extends PublishJobStatusApiModel {
   datasets: DatasetModel[]
 }
 
+marker('datafeeder.publishSuccess.geonetworkRecord')
+marker('datafeeder.publishSuccess.mapViewer')
+marker('datafeeder.publishSuccess.ogcFeature')
+
 @Component({
   selector: 'gn-ui-success-publish-page',
   templateUrl: './success-publish-page.component.html',
@@ -33,6 +39,7 @@ export class SuccessPublishPageComponent implements OnInit, OnDestroy {
   gnLink: string
   gsLink: string
   ogcLink: string
+  linksToDisplay: { uri: string, label: any }[] = []
 
   constructor(
     private facade: DatafeederFacade,
@@ -49,36 +56,49 @@ export class SuccessPublishPageComponent implements OnInit, OnDestroy {
         .pipe(take(1))
         .subscribe((job: JobStatusModel) => {
           const links = job.datasets[0]._links
-          this.gsLink = links.preview?.href
-          this.http
-            .get(this.gsLink, { observe: 'response', responseType: 'text' })
-            .subscribe((data) => {
-              if (
-                data.headers.get('content-type') === 'text/xml;charset=utf-8' &&
-                data.body?.includes('NullPointerException')
-              ) {
-                this.gsLink = ''
-              }
-            })
-          this.gnLink = links.describedBy[1].href.replace(
-            '/eng/',
-            `/${LANG_2_TO_3_MAPPER[this.translateService.currentLang]}/`
-          )
-          this.ogcLink = links.hosts?.href
+          const linksFromConfig = SETTINGS.links
+          // Existing links
+          linksFromConfig.existing?.forEach((link) => {
+            if (link === ('geonetwork')) {
+              this.gnLink = links.describedBy[1].href.replace(
+                '/eng/',
+                `/${LANG_2_TO_3_MAPPER[this.translateService.currentLang]}/`
+              )
+              this.linksToDisplay.push({uri: this.gnLink, label: this.translateService.instant('datafeeder.publishSuccess.geonetworkRecord')})
+            } else if (link === ('openlayers')) {
+              this.gsLink = links.preview?.href
+              this.http
+                .get(this.gsLink, { observe: 'response', responseType: 'text' })
+                .subscribe((data) => {
+                  if (
+                    data.headers.get('content-type') === 'text/xml;charset=utf-8' &&
+                    data.body?.includes('NullPointerException')
+                  ) {
+                    this.gsLink = ''
+                  } else {
+                    this.linksToDisplay.push({uri: this.gsLink, label: this.translateService.instant('datafeeder.publishSuccess.mapViewer')})
+                  }
+                })
+            } else if (link === ('ogc-features')) {
+              this.ogcLink = links.hosts?.href
+              if (this.ogcLink)
+                this.linksToDisplay.push({uri: this.ogcLink, label: this.translateService.instant('datafeeder.publishSuccess.ogcFeature')})
+            }
+          })
+          //Custom links
+          linksFromConfig.custom?.forEach((link) => {
+            this.linksToDisplay.push({uri: this.replaceVars(link.uri, job.datasets[0]), label: link.title[this.translateService.currentLang] || link.title.default})
+          })
         })
     )
   }
 
-  openGeonetworkLink() {
-    window.open(this.gnLink, '_blank')
+  openLink(link: string) {
+    window.open(link, '_blank')
   }
 
-  openGeoserverLink() {
-    window.open(this.gsLink, '_blank')
-  }
-
-  openOgcLink() {
-    window.open(this.ogcLink, '_blank')
+  replaceVars(uri: string, job: DatasetModel) {
+    return uri.replace(':uuid', job.metadataRecordId || '').replace(':lang', this.translateService.currentLang)
   }
 
   backToHome() {

--- a/apps/datafeeder/src/settings.ts
+++ b/apps/datafeeder/src/settings.ts
@@ -36,10 +36,19 @@ class Settings {
   ]
   thesaurusUrl = `/geonetwork/srv/api/registries/vocabularies/search?type=CONTAINS&thesaurus=external.theme.inspire-theme&rows=200&q=$\{q}&uri=**&lang=$\{lang}`
   maxFileUploadSize = '-1'
+  links = {
+    existing: [],
+    custom: [{ uri: '', title: { default: '', fr: ''}}]
+  }
   init() {
     return fetch(SETTING_API)
       .then((response) => response.json())
       .then((json) => {
+        if (!json.links){
+          json.links = { existing : ["geonetwork",
+              "openlayers",
+              "ogc-features"]}
+        }
         Object.assign(this, json)
       })
   }

--- a/apps/datafeeder/src/settings.ts
+++ b/apps/datafeeder/src/settings.ts
@@ -36,18 +36,15 @@ class Settings {
   ]
   thesaurusUrl = `/geonetwork/srv/api/registries/vocabularies/search?type=CONTAINS&thesaurus=external.theme.inspire-theme&rows=200&q=$\{q}&uri=**&lang=$\{lang}`
   maxFileUploadSize = '-1'
-  links = {
-    existing: [],
-    custom: [{ uri: '', title: { default: '', fr: ''}}]
-  }
+  links = []
   init() {
     return fetch(SETTING_API)
       .then((response) => response.json())
       .then((json) => {
         if (!json.links){
-          json.links = { existing : ["geonetwork",
+          json.links = ["geonetwork",
               "openlayers",
-              "ogc-features"]}
+              "ogc-features"]
         }
         Object.assign(this, json)
       })


### PR DESCRIPTION
With editing the [`frontend-config.json`](https://github.com/georchestra/datadir/blob/master/datafeeder/frontend-config.json) file in datadir for datafeeder, we can now change the links at the end of the process.

Here is the structure to add :
```json
"links": 
    [
      "geonetwork", "openlayers", "ogc-features",  
      {
        "uri": "/datahub/dataset/:uuid",
        "title": {
          "default": "See data in Datahub",
          "fr": "Voir le jeu de données dans datahub"
        }
      }
    ]
   
```
With this example (and if data-api is set too), it will display 4 links :
- Geonetwork
- OpenLayers (geoserver)
- Ogc features (data api and if `datafeeder.publishing.ogcfeatures.public-url` is set in `datafeeder.properties`)
- Datahub (the custom one)

**This work is sponsored by MEL**. 
